### PR TITLE
Merge from mistval_dev

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -110,6 +110,8 @@ jobs:
         run: npm ci --prefix server
 
       - name: Build frontend
+        env:
+          VITE_GITHUB_RELEASE_TAG: '$TAG_NAME'
         run: npm run build:web
 
       - name: Build backend

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in contributing to Yozakura.
 
 This is a new project without particularly formal contribution requirements. Please just heed the following guidelines.
 
-1. Before working on a major feature, consider starting a discussion in [https://github.com/mistval/yozakura/discussions](discussions) and propose your motivation and intended approach.
+1. Before working on a major feature, consider starting a discussion in [discussions](https://github.com/mistval/yozakura/discussions) and propose your motivation and intended approach.
 2. Pull requests should go to the `dev` branch.
 3. Most significant pull requests will likely require at least a couple rounds of code review.
 4. Please make an effort to strictly adhere to type-safe coding approaches (using Zod for validation).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,9 @@ This is a new project without particularly formal contribution requirements. Ple
 1. Before working on a major feature, consider starting a discussion in [discussions](https://github.com/mistval/yozakura/discussions) and propose your motivation and intended approach.
 2. Pull requests should go to the `dev` branch.
 3. Most significant pull requests will likely require at least a couple rounds of code review.
-4. Please make an effort to strictly adhere to type-safe coding approaches (using Zod for validation).
+4. Please make an effort to strictly adhere to type-safe coding approaches (using Zod for validation) and immutability.
+5. You must be the author of any code you contribute.
+6. AI-generated code counts, but contributors must understand the code and are responsible for it, so strictly vibe-coded features likely won't get merged.
 
 ## Scope & Vision
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing
+
+Thanks for your interest in contributing to Yozakura.
+
+This is a new project without particularly formal contribution requirements. Please just heed the following guidelines.
+
+1. Before working on a major feature, consider starting a discussion in [https://github.com/mistval/yozakura/discussions](discussions) and propose your motivation and intended approach.
+2. Pull requests should go to the `dev` branch.
+3. Most significant pull requests will likely require at least a couple rounds of code review.
+4. Please make an effort to strictly adhere to type-safe coding approaches (using Zod for validation).
+
+## Scope & Vision
+
+Features added as core features in Yozakura should be applicable to any imaginable scenario.
+
+For example something like a "theft" system might not be a good fit, as the consequences of stealing can vary dramatically between different fictional worlds.
+
+There are some gray areas, for example the existing memory system clearly wouldn't work in a world where "people don't have memories". So it's not always 100% clear-cut what fits the core vision and what doesn't, and it can be a discussion.
+
+Ultimately, a key roadmap item is to add internal tool calling for agents so that users could implement a theft system where their LLM has the ability to `moveCharacter()` into the prison if they do something untoward.
+
+I would say that the core scope of Yozakura is essentially: character CRUD, map CRUD, scenario CRUD, the turn loop, character movement, the chat loop, the memory system. With the caveat that I intend to spin off the memory system into something more extensible and less fundamental to the system (user-defined memory processing steps and memory types).

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,6 @@ ENV YOZAKURA_FRONTEND_DIST_DIR=/app/client/dist
 EXPOSE 4396
 VOLUME ["/app/data"]
 
-HEALTHCHECK --interval=30s --timeout=3s --start-period=20s --retries=3 CMD node -e "fetch('http://127.0.0.1:3001/health').then((response) => { if (!response.ok) process.exit(1); }).catch(() => process.exit(1));"
+HEALTHCHECK --interval=30s --timeout=3s --start-period=20s --retries=3 CMD node -e "fetch('http://127.0.0.1:4396/health').then((response) => { if (!response.ok) process.exit(1); }).catch(() => process.exit(1));"
 
 CMD ["node", "server/dist/index.js"]

--- a/client/src/backend_bridge/api.ts
+++ b/client/src/backend_bridge/api.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
-import { parseJSONResponse, type LlmChatOptions, withInfiniteRetry, executeLlmChat } from './api_helpers';
+import { parseJSONResponse, type LlmChatOptions, executeLlmChat } from './api_helpers';
+import { runWithInteractiveRetry } from '../engine/interative_retry';
 import { assert } from '../errors/application_error';
+
+const DEFAULT_API_RETRY_HINT =
+  'The backend server might not be running or downstream services might be unavailable.';
 
 const zodEmpty = z.object({});
 
@@ -21,51 +25,59 @@ const dbRunResponseType = z.object({});
 
 type DbParameterGroup = unknown[];
 
-export const putFile = withInfiniteRetry({
-  operationType: 'api.upload_file',
-  execute: async (path: string, file: Blob, contentType?: string) => {
-    assert(path.startsWith('/api/files/'), 'Can only PUT files starting with /api/files/');
+export const putFile = (path: string, file: Blob, contentType?: string) =>
+  runWithInteractiveRetry({
+    operationType: 'api.upload_file',
+    hint: DEFAULT_API_RETRY_HINT,
+    run: async () => {
+      assert(path.startsWith('/api/files/'), 'Can only PUT files starting with /api/files/');
 
-    const response = await fetch(path, {
-      method: 'PUT',
-      headers: {
-        'Content-Type': contentType || (file && file.type) || 'application/octet-stream',
-      },
-      body: file,
-    });
+      const response = await fetch(path, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': contentType || (file && file.type) || 'application/octet-stream',
+        },
+        body: file,
+      });
 
-    return parseJSONResponse(zodEmpty, response);
-  },
-});
+      return parseJSONResponse(zodEmpty, response);
+    },
+  });
 
-export const deleteFile = withInfiniteRetry({
-  operationType: 'api.delete_path',
-  execute: async (path: string) => {
-    assert(path.startsWith('/api/files/'), 'Can only DELETE files starting with /api/files/');
+export const deleteFile = (path: string) =>
+  runWithInteractiveRetry({
+    operationType: 'api.delete_path',
+    hint: DEFAULT_API_RETRY_HINT,
+    run: async () => {
+      assert(path.startsWith('/api/files/'), 'Can only DELETE files starting with /api/files/');
 
-    const response = await fetch(path, {
-      method: 'DELETE',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
+      const response = await fetch(path, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
 
-    return parseJSONResponse(zodEmpty, response);
-  },
-});
+      return parseJSONResponse(zodEmpty, response);
+    },
+  });
 
 export const llmChat = (payload: Record<string, unknown>, options: LlmChatOptions = {}) =>
   executeLlmChat(payload, options);
 
-export const generateImage = withInfiniteRetry({
-  operationType: 'api.generate_image',
-  execute: (payload: Record<string, unknown>) =>
-    fetch('/api/image/generate', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    }).then((r) => parseJSONResponse(imageResponseType, r)),
-});
+export const generateImage = (payload: Record<string, unknown>, signal?: AbortSignal) =>
+  runWithInteractiveRetry({
+    operationType: 'api.generate_image',
+    hint: DEFAULT_API_RETRY_HINT,
+    signal,
+    run: () =>
+      fetch('/api/image/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+        signal: signal ?? null,
+      }).then((r) => parseJSONResponse(imageResponseType, r)),
+  });
 
 export async function dbExec(sql: string) {
   const response = await fetch('/api/db/exec', {

--- a/client/src/backend_bridge/api_helpers.ts
+++ b/client/src/backend_bridge/api_helpers.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { runWithInteractiveRetry } from '../engine/interative_retry';
 import { ApplicationError } from '../errors/application_error';
 
 type LlmTokenCallback = (fullText: string) => void;
@@ -8,20 +7,8 @@ export type LlmChatOptions = {
   targetUrl?: string | undefined;
   authToken?: string | undefined;
   onTokens?: LlmTokenCallback;
+  signal?: AbortSignal;
 };
-
-type RetryHintResolver = (error: unknown, attempt: number) => string | undefined;
-
-type AsyncApiCall<TArgs extends unknown[], TResult> = (...args: TArgs) => Promise<TResult>;
-
-type RetriedApiCallDefinition<TArgs extends unknown[], TResult> = {
-  operationType: string;
-  execute: AsyncApiCall<TArgs, TResult>;
-  hint?: string | RetryHintResolver;
-};
-
-const DEFAULT_API_RETRY_HINT =
-  'The backend server might not be running or downstream services might be unavailable.';
 
 const openAIChatCompletionSchema = z.object({
   choices: z.array(
@@ -164,7 +151,7 @@ async function parseLlmStreamingResponse(response: Response, onTokens: LlmTokenC
 }
 
 export async function executeLlmChat(payload: Record<string, unknown>, options: LlmChatOptions = {}) {
-  const { targetUrl, authToken, onTokens } = options;
+  const { targetUrl, authToken, onTokens, signal } = options;
   const streamingRequested = typeof onTokens === 'function';
 
   if (streamingRequested) {
@@ -184,6 +171,7 @@ export async function executeLlmChat(payload: Record<string, unknown>, options: 
       targetUrl,
       authToken,
     }),
+    signal: signal ?? null,
   });
 
   if (!response.ok) {
@@ -197,17 +185,6 @@ export async function executeLlmChat(payload: Record<string, unknown>, options: 
 
   const completion = await parseJSONResponse(openAIChatCompletionSchema, response);
   return completion?.choices?.[0]?.message?.content || '';
-}
-
-export function withInfiniteRetry<TArgs extends unknown[], TResult>(
-  definition: RetriedApiCallDefinition<TArgs, TResult>
-): AsyncApiCall<TArgs, TResult> {
-  return (...args: TArgs) =>
-    runWithInteractiveRetry<TResult>({
-      operationType: definition.operationType,
-      hint: definition.hint ?? DEFAULT_API_RETRY_HINT,
-      run: () => definition.execute(...args),
-    });
 }
 
 export async function parseJSONResponse<TZodType>(

--- a/client/src/backend_bridge/database.ts
+++ b/client/src/backend_bridge/database.ts
@@ -37,94 +37,6 @@ function sqlDatetimeNow() {
   return `CONCAT(datetime('now'), 'Z')`;
 }
 
-const CREATE_MULTI_TABLES_SQL = `
-  CREATE TABLE IF NOT EXISTS ${TABLE_CHARACTER} (
-    id TEXT PRIMARY KEY,
-    data TEXT NOT NULL,
-    created_at TEXT NOT NULL DEFAULT (${sqlDatetimeNow()}),
-    updated_at TEXT NOT NULL DEFAULT (${sqlDatetimeNow()})
-  );
-
-  CREATE TABLE IF NOT EXISTS ${TABLE_SCENARIO_CHARACTER} (
-    id TEXT PRIMARY KEY,
-    scenario_id TEXT NOT NULL,
-    data TEXT NOT NULL,
-    created_at TEXT NOT NULL DEFAULT (${sqlDatetimeNow()}),
-    updated_at TEXT NOT NULL DEFAULT (${sqlDatetimeNow()}),
-    FOREIGN KEY (scenario_id) REFERENCES ${TABLE_SCENARIO}(id) ON DELETE CASCADE
-  );
-
-  CREATE INDEX IF NOT EXISTS idx_scenario_character_scenario_character
-    ON ${TABLE_SCENARIO_CHARACTER}(scenario_id);
-
-  CREATE TABLE IF NOT EXISTS ${TABLE_SCENARIO} (
-    id TEXT PRIMARY KEY,
-    data TEXT NOT NULL,
-    created_at TEXT NOT NULL DEFAULT (${sqlDatetimeNow()}),
-    updated_at TEXT NOT NULL DEFAULT (${sqlDatetimeNow()})
-  );
-
-  CREATE TABLE IF NOT EXISTS ${TABLE_CHARACTER_RELATIONSHIP} (
-    id TEXT PRIMARY KEY,
-    from_id TEXT NOT NULL,
-    to_id TEXT NOT NULL,
-    data TEXT NOT NULL,
-    created_at TEXT NOT NULL DEFAULT (${sqlDatetimeNow()}),
-    updated_at TEXT NOT NULL DEFAULT (${sqlDatetimeNow()}),
-    UNIQUE(from_id, to_id),
-    FOREIGN KEY (from_id) REFERENCES ${TABLE_SCENARIO_CHARACTER}(id) ON DELETE CASCADE,
-    FOREIGN KEY (to_id) REFERENCES ${TABLE_SCENARIO_CHARACTER}(id) ON DELETE CASCADE
-  );
-
-  CREATE INDEX IF NOT EXISTS idx_character_relationship_from_to
-    ON ${TABLE_CHARACTER_RELATIONSHIP}(from_id, to_id);
-
-  CREATE INDEX IF NOT EXISTS idx_character_relationship_to_from
-    ON ${TABLE_CHARACTER_RELATIONSHIP}(to_id, from_id);
-
-  CREATE TABLE IF NOT EXISTS ${TABLE_CONVERSATION} (
-    id TEXT PRIMARY KEY,
-    scenario_id TEXT NOT NULL,
-    data TEXT NOT NULL,
-    created_at TEXT NOT NULL DEFAULT (${sqlDatetimeNow()}),
-    updated_at TEXT NOT NULL DEFAULT (${sqlDatetimeNow()}),
-    FOREIGN KEY (scenario_id) REFERENCES ${TABLE_SCENARIO}(id) ON DELETE CASCADE
-  );
-
-  CREATE INDEX IF NOT EXISTS idx_conversation_scenario_updated_at_desc
-    ON ${TABLE_CONVERSATION}(scenario_id, updated_at DESC);
-
-  CREATE TABLE IF NOT EXISTS ${TABLE_CONVERSATION_PARTICIPANT} (
-    id TEXT PRIMARY KEY,
-    character_id TEXT NOT NULL,
-    conversation_id TEXT NOT NULL,
-    created_at TEXT NOT NULL DEFAULT (${sqlDatetimeNow()}),
-    updated_at TEXT NOT NULL DEFAULT (${sqlDatetimeNow()}),
-    UNIQUE(character_id, conversation_id),
-    FOREIGN KEY (conversation_id) REFERENCES ${TABLE_CONVERSATION}(id) ON DELETE CASCADE
-  );
-
-  CREATE INDEX IF NOT EXISTS idx_conversation_participant_character_updated_at_desc
-    ON ${TABLE_CONVERSATION_PARTICIPANT}(character_id, updated_at DESC);
-
-  CREATE INDEX IF NOT EXISTS idx_conversation_participant_conversation_character
-    ON ${TABLE_CONVERSATION_PARTICIPANT}(conversation_id, character_id);
-
-  CREATE TABLE IF NOT EXISTS ${TABLE_MAP} (
-    id TEXT PRIMARY KEY,
-    data TEXT NOT NULL,
-    created_at TEXT NOT NULL DEFAULT (${sqlDatetimeNow()}),
-    updated_at TEXT NOT NULL DEFAULT (${sqlDatetimeNow()})
-  );
-
-  CREATE TABLE IF NOT EXISTS ${TABLE_KEY_VALUE} (
-    key TEXT PRIMARY KEY,
-    data TEXT NOT NULL,
-    created_at TEXT NOT NULL DEFAULT (${sqlDatetimeNow()}),
-    updated_at TEXT NOT NULL DEFAULT (${sqlDatetimeNow()})
-  );
-`;
-
 const UPSERT_CHARACTER_SQL = `
   INSERT INTO ${TABLE_CHARACTER} (id, data, created_at, updated_at)
   SELECT
@@ -349,27 +261,11 @@ type ConversationPageResult = {
   hasNextPage: boolean;
 };
 
-let dbSchemaReadyPromise: Promise<void> | undefined = undefined;
-
-function ensureDbSchema() {
-  if (!dbSchemaReadyPromise) {
-    dbSchemaReadyPromise = Api.dbExec(CREATE_MULTI_TABLES_SQL)
-      .then(() => undefined)
-      .catch((error) => {
-        dbSchemaReadyPromise = undefined;
-        throw error;
-      });
-  }
-
-  return dbSchemaReadyPromise;
-}
-
 async function selectUntypedMultiQuery(statement: string, parameterGroups: unknown[][]) {
   if (parameterGroups.length === 0) {
     return [];
   }
 
-  await ensureDbSchema();
   const response = await Api.dbAll(statement, parameterGroups);
   return response.results.flat();
 }
@@ -419,7 +315,6 @@ async function dbRun(statement: string, parameterGroups: unknown[][]) {
     return;
   }
 
-  await ensureDbSchema();
   await Api.dbRun(statement, parameterGroups);
 }
 

--- a/client/src/components/LocationPanel.tsx
+++ b/client/src/components/LocationPanel.tsx
@@ -10,6 +10,7 @@ type LocationPanelProps = {
   onMove: (locationId: string) => void;
   onWait?: () => void;
   disabled?: boolean;
+  canMove?: boolean;
 };
 
 export default function LocationPanel({
@@ -18,6 +19,7 @@ export default function LocationPanel({
   onMove,
   onWait,
   disabled,
+  canMove = true,
 }: LocationPanelProps) {
   return (
     <div className="space-y-3">
@@ -26,21 +28,23 @@ export default function LocationPanel({
         <p className="font-semibold">{location.description}</p>
       </div>
 
-      <div>
-        <div className="font-semibold mb-1">Move to</div>
-        <div className="flex gap-2 flex-wrap">
-          {adjacentLocationIds.map((location) => (
-            <button key={location.id} type="button" onClick={() => onMove(location.id)} disabled={disabled}>
-              {location.name}
-            </button>
-          ))}
-          {onWait && (
-            <button type="button" onClick={onWait} disabled={disabled}>
-              Wait
-            </button>
-          )}
+      {canMove && (
+        <div>
+          <div className="font-semibold mb-1">Move to</div>
+          <div className="flex gap-2 flex-wrap">
+            {adjacentLocationIds.map((location) => (
+              <button key={location.id} type="button" onClick={() => onMove(location.id)} disabled={disabled}>
+                {location.name}
+              </button>
+            ))}
+            {onWait && (
+              <button type="button" onClick={onWait} disabled={disabled}>
+                Wait
+              </button>
+            )}
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/client/src/components/character_overview/CharacterOverviewPairData.tsx
+++ b/client/src/components/character_overview/CharacterOverviewPairData.tsx
@@ -336,6 +336,21 @@ export default function CharacterOverviewPairData({
                               }
                             );
                           }}
+                          onDelete={() => {
+                            const updatedSummaries = section.summaries.filter(
+                              (_, entryIndex) => entryIndex !== index
+                            );
+
+                            return saveRelationshipPatch(
+                              {
+                                fromId: section.fromId,
+                                toId: section.toId,
+                              },
+                              {
+                                rollingPairwiseSummaries: updatedSummaries,
+                              }
+                            );
+                          }}
                         >
                           {summary.summary || '(none)'}
                         </SpoilerSection>
@@ -373,6 +388,21 @@ export default function CharacterOverviewPairData({
                                       information: newValue,
                                     }
                                   : entry
+                            );
+
+                            return saveRelationshipPatch(
+                              {
+                                fromId: section.fromId,
+                                toId: section.toId,
+                              },
+                              {
+                                rollingOffscreenLearnedInformation: updatedInformations,
+                              }
+                            );
+                          }}
+                          onDelete={() => {
+                            const updatedInformations = section.learnedInformations.filter(
+                              (_, entryIndex) => entryIndex !== index
                             );
 
                             return saveRelationshipPatch(

--- a/client/src/components/ui/Modal.tsx
+++ b/client/src/components/ui/Modal.tsx
@@ -33,6 +33,7 @@ export default function Modal({
   zIndex,
 }: ModalProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const mouseDownOutside = useRef<boolean>(false);
 
   const setContainerRef: React.RefCallback<HTMLDivElement> = (node) => {
     containerRef.current = node;
@@ -72,8 +73,17 @@ export default function Modal({
 
   if (!open) return undefined;
 
+  const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target !== e.currentTarget) {
+      mouseDownOutside.current = true;
+    }
+  };
+
   const handleOutsideClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (!closeOnBackdropClick || !onClose) {
+    const wasDownOutside = mouseDownOutside.current;
+    mouseDownOutside.current = false;
+
+    if (!closeOnBackdropClick || !onClose || wasDownOutside) {
       return;
     }
 
@@ -93,6 +103,7 @@ export default function Modal({
           ref={setContainerRef}
           className={`h-full overflow-y-auto ${className}`}
           onClick={handleOutsideClick}
+          onMouseDown={handleMouseDown}
         >
           {children}
         </div>

--- a/client/src/components/ui/SpoilerSection.tsx
+++ b/client/src/components/ui/SpoilerSection.tsx
@@ -9,6 +9,7 @@ export function SpoilerSection({
   defaultRevealed,
   className = '',
   onSave,
+  onDelete,
 }: {
   title: string;
   children: ReactNode;
@@ -16,6 +17,7 @@ export function SpoilerSection({
   defaultRevealed?: boolean;
   className?: string;
   onSave?: (value: string) => Promise<void> | void;
+  onDelete?: () => Promise<void> | void;
 }) {
   const [revealed, setRevealed] = useState(defaultRevealed ?? false);
   const [saved, setSaved] = useState(false);
@@ -62,6 +64,16 @@ export function SpoilerSection({
     }
   };
 
+  const handleDelete = async () => {
+    if (!onDelete || savingRef.current) return;
+    setSaving(true);
+    try {
+      await onDelete();
+    } finally {
+      setSaving(false);
+    }
+  };
+
   return (
     <div className={`border rounded-sm p-3 ${className}`}>
       <button
@@ -83,6 +95,16 @@ export function SpoilerSection({
             onChange={(event) => setDraft(event.target.value)}
           />
           <div className="flex items-center justify-end gap-2">
+            {onDelete && (
+              <button
+                type="button"
+                className="border-danger-border-accent bg-danger-solid text-on-accent hover:bg-danger-solid-hover"
+                onClick={handleDelete}
+                disabled={saving}
+              >
+                Delete
+              </button>
+            )}
             {saved ? (
               <span className="text-sm text-success-text">Saved ✓</span>
             ) : (

--- a/client/src/engine/chat/chat_coordinator.ts
+++ b/client/src/engine/chat/chat_coordinator.ts
@@ -205,74 +205,62 @@ export class ChatCoordinator {
     const speaker = useScenarioCharacterStore.getState().getRequiredCharacterById(npcId);
     const completionRequestId = newId();
 
-    try {
-      const promptContext = await buildFocusedChatTemplateContext(speaker.id);
-      const renderedPrompts = await chatSystemPromptChain.render(promptContext, {
-        completionRequestId,
-      });
+    const promptContext = await buildFocusedChatTemplateContext(speaker.id);
+    const renderedPrompts = await chatSystemPromptChain.render(promptContext, {
+      completionRequestId,
+    });
 
-      const aiPromptMessages = this.transcript().toAIPromptMessages(speaker.id);
-      const prompts = [renderedPrompts[0]!].concat(aiPromptMessages);
+    const aiPromptMessages = this.transcript().toAIPromptMessages(speaker.id);
+    const prompts = [renderedPrompts[0]!].concat(aiPromptMessages);
 
-      if (aiPromptMessages.length > 0) {
-        prompts.push(renderedPrompts[1]!);
-      }
+    if (aiPromptMessages.length > 0) {
+      prompts.push(renderedPrompts[1]!);
+    }
 
-      const userNudgePrompt = renderedPrompts[2];
-      if (userNudgePrompt?.content) {
-        prompts.push(userNudgePrompt);
-      }
+    const userNudgePrompt = renderedPrompts[2];
+    if (userNudgePrompt?.content) {
+      prompts.push(userNudgePrompt);
+    }
 
-      const tokenStreamingEnabled = useSettingsStore.getState().tokenStreamingEnabled;
+    const tokenStreamingEnabled = useSettingsStore.getState().tokenStreamingEnabled;
 
-      if (!tokenStreamingEnabled) {
-        const response = await chatCompletion(prompts, {
-          promptTemplateGroup: 'gen_npc_response',
-          completionRequestId,
-          promptContext,
-        });
-
-        const parsedResponse = await chatSystemPromptChain.parse(response, promptContext, {
-          completionRequestId,
-        });
-
-        await this.addCharacterMessage(speaker.id, parsedResponse);
-        await this.pauseAfterNpcOnlyMessage();
-
-        return this.transcript;
-      }
-
-      const draftMessage = this.startStreamingNpcDraftMessage(speaker);
-
+    if (!tokenStreamingEnabled) {
       const response = await chatCompletion(prompts, {
         promptTemplateGroup: 'gen_npc_response',
-        promptContext,
         completionRequestId,
-        onTokens: (fullText: string) => {
-          this.setTranscript(this.transcript().editLatestMessage(fullText).updatedTranscript);
-        },
+        promptContext,
       });
 
       const parsedResponse = await chatSystemPromptChain.parse(response, promptContext, {
         completionRequestId,
       });
 
-      // We delete and re-add in order to trigger certain effects like memory RAG
-      this.deleteMessageById(draftMessage.id);
       await this.addCharacterMessage(speaker.id, parsedResponse);
-
       await this.pauseAfterNpcOnlyMessage();
-    } catch (err) {
-      const mostRecentMessage = this.transcript().getMostRecentMessage();
-      if (mostRecentMessage && !mostRecentMessage.getContent()) {
-        this.setTranscript(this.transcript().deleteMessageById(mostRecentMessage.getId()).updatedTranscript);
-      }
 
-      await showNonRetriableErrorCardIfNeeded({
-        error: err,
-        operationType: 'chat.npc.speak',
-      });
+      return this.transcript;
     }
+
+    const draftMessage = this.startStreamingNpcDraftMessage(speaker);
+
+    const response = await chatCompletion(prompts, {
+      promptTemplateGroup: 'gen_npc_response',
+      promptContext,
+      completionRequestId,
+      onTokens: (fullText: string) => {
+        this.setTranscript(this.transcript().editLatestMessage(fullText).updatedTranscript);
+      },
+    });
+
+    const parsedResponse = await chatSystemPromptChain.parse(response, promptContext, {
+      completionRequestId,
+    });
+
+    // We delete and re-add in order to trigger certain effects like memory RAG
+    this.deleteMessageById(draftMessage.id);
+    await this.addCharacterMessage(speaker.id, parsedResponse);
+
+    await this.pauseAfterNpcOnlyMessage();
 
     return this.transcript;
   }

--- a/client/src/engine/chat/chat_coordinator.ts
+++ b/client/src/engine/chat/chat_coordinator.ts
@@ -3,9 +3,9 @@ import { chatCompletion } from '../llm.js';
 import { showNonRetriableErrorCardIfNeeded } from '../interative_retry.js';
 import { buildFullPrompt, generateChatImage } from '../image_gen.js';
 import {
-  buildTargetedChatTemplateContext,
   buildChatModeratorContext,
   buildFocusedChatTemplateContext,
+  buildMemoryRagTemplateContext,
 } from '../prompt_templates/prompt_context_builder';
 import { useSettingsStore, type SpeakerSelectionMode } from '../../state/settings_store.js';
 import * as Database from '../../backend_bridge/database.js';
@@ -501,10 +501,9 @@ export class ChatCoordinator {
       for (const participant of getActiveChatParticipants({ includeUser: false })) {
         const focusedCharacter = this.getCharacterById(participant.id);
 
-        const reminder = await memoryRagPromptTemplatesGroup.render({
-          ...(await buildTargetedChatTemplateContext(focusedCharacter.id, mentionedCharacter.id)),
-          mentionedByCharacter,
-        });
+        const reminder = await memoryRagPromptTemplatesGroup.render(
+          await buildMemoryRagTemplateContext(focusedCharacter, mentionedCharacter, mentionedByCharacter)
+        );
 
         this.setTranscript(
           this.transcript().addOffscreenRagMessage(participant.id, reminder[0]!.content, mentionedCharacter)

--- a/client/src/engine/image_gen.ts
+++ b/client/src/engine/image_gen.ts
@@ -1,6 +1,7 @@
 import * as Api from '../backend_bridge/api';
 import { assertNonNullish } from '../errors/application_error.js';
 import { useSettingsStore } from '../state/settings_store.js';
+import { withPhaseTransitionGate } from '../util/phase_transition_gate.js';
 import type { Character } from './types.js';
 
 function buildImagePayload(prompt: string, style: 'chat' | 'card', saveTo?: string): Record<string, unknown> {
@@ -101,8 +102,11 @@ export async function generateChatImage({
   fullPrompt: string;
   saveTo: string;
 }): Promise<string[]> {
-  const payload = buildImagePayload(fullPrompt, 'chat', saveTo);
-  const result = await Api.generateImage(payload);
+  // Pause/abort before the image generation call, honoring the user's NPC-turn pause/stop.
+  return withPhaseTransitionGate(async (signal) => {
+    const payload = buildImagePayload(fullPrompt, 'chat', saveTo);
+    const result = await Api.generateImage(payload, signal);
 
-  return result.files;
+    return result.files;
+  });
 }

--- a/client/src/engine/interative_retry.ts
+++ b/client/src/engine/interative_retry.ts
@@ -15,6 +15,7 @@ type RunWithInteractiveRetryOptions<T> = {
   maxRetries?: number;
   shouldRetry?: (error: unknown, attempt: number) => boolean;
   hint?: string | ((error: unknown, attempt: number) => string | undefined);
+  signal?: AbortSignal | undefined;
 };
 
 type Deferred<T> = {
@@ -224,6 +225,10 @@ export async function runWithInteractiveRetry<T>(options: RunWithInteractiveRetr
         return result;
       } catch (error) {
         if (error instanceof InteractiveRetryError) {
+          throw error;
+        }
+
+        if (options.signal?.aborted) {
           throw error;
         }
 

--- a/client/src/engine/llm.ts
+++ b/client/src/engine/llm.ts
@@ -6,6 +6,7 @@ import { useSettingsStore } from '../state/settings_store.js';
 import { usePromptLogStore } from '../state/prompt_log_store.js';
 import { useTemplateRenderLogStore } from '../state/template_render_log_store.js';
 import { getErrorMessage } from '../errors/error_util.js';
+import { withPhaseTransitionGate } from '../util/phase_transition_gate.js';
 import type { PromptExecutionContext } from './prompt_templates/prompt_template_context_fields';
 
 type ResponsePreParser = (response: string) => string;
@@ -183,48 +184,52 @@ export async function chatCompletion(
   messages: PromptMessage[],
   options: ChatCompletionOptions
 ): Promise<string> {
-  return runWithInteractiveRetry<string>({
-    operationType: 'api.llm_completion',
-    maxRetries: Number.POSITIVE_INFINITY,
-    run: async () => {
-      const { promptTemplateGroup, onTokens, completionRequestId, promptContext, ...llmOptions } = options;
-      const resolvedPromptOptions = resolveLlmPromptOptions(promptTemplateGroup, promptContext);
+  // Pause/abort before the LLM call (and outside the retry loop, so an abort is not retried).
+  return withPhaseTransitionGate((signal) =>
+    runWithInteractiveRetry<string>({
+      operationType: 'api.llm_completion',
+      maxRetries: Number.POSITIVE_INFINITY,
+      signal,
+      run: async () => {
+        const { promptTemplateGroup, onTokens, completionRequestId, promptContext, ...llmOptions } = options;
+        const resolvedPromptOptions = resolveLlmPromptOptions(promptTemplateGroup, promptContext);
 
-      const payload = {
-        ...resolvedPromptOptions.metaOptions,
-        ...llmOptions,
-        messages,
-      };
+        const payload = {
+          ...resolvedPromptOptions.metaOptions,
+          ...llmOptions,
+          messages,
+        };
 
-      const transportOptions: LlmTransportOptions = {
-        targetUrl: resolvedPromptOptions.targetUrl,
-        authToken: resolvedPromptOptions.authToken,
-        ...(useSettingsStore.getState().tokenStreamingEnabled && onTokens ? { onTokens } : {}),
-      };
+        const transportOptions: LlmTransportOptions = {
+          targetUrl: resolvedPromptOptions.targetUrl,
+          authToken: resolvedPromptOptions.authToken,
+          ...(useSettingsStore.getState().tokenStreamingEnabled && onTokens ? { onTokens } : {}),
+        };
 
-      const responseText = await Api.llmChat(payload, transportOptions);
+        const responseText = await Api.llmChat(payload, { ...transportOptions, signal });
 
-      usePromptLogStore.getState().addEntry({
-        payloadJson: stringifyForPromptLog(payload),
-        transportOptionsJson: sanitizeTransportOptionsForPromptLog(transportOptions),
-        responseJson: stringifyForPromptLog(responseText),
-      });
-
-      if (completionRequestId) {
-        useTemplateRenderLogStore.getState().postTemplateRender({
-          completionRequestId,
-          completions: {
-            rawResponse: responseText,
-          },
+        usePromptLogStore.getState().addEntry({
+          payloadJson: stringifyForPromptLog(payload),
+          transportOptionsJson: sanitizeTransportOptionsForPromptLog(transportOptions),
+          responseJson: stringifyForPromptLog(responseText),
         });
-      }
 
-      const cleaned = cleanLlmText(responseText, resolvedPromptOptions.responsePreParserSource);
-      if (!cleaned) {
-        throw new Error('Empty LLM response');
-      }
+        if (completionRequestId) {
+          useTemplateRenderLogStore.getState().postTemplateRender({
+            completionRequestId,
+            completions: {
+              rawResponse: responseText,
+            },
+          });
+        }
 
-      return cleaned;
-    },
-  });
+        const cleaned = cleanLlmText(responseText, resolvedPromptOptions.responsePreParserSource);
+        if (!cleaned) {
+          throw new Error('Empty LLM response');
+        }
+
+        return cleaned;
+      },
+    })
+  );
 }

--- a/client/src/engine/prompt_templates/character_generation/wardrobe_generation.ts
+++ b/client/src/engine/prompt_templates/character_generation/wardrobe_generation.ts
@@ -27,16 +27,29 @@ Rules:
 class WardrobeGenerationUserTemplate extends PromptTemplateBase<
   z.infer<typeof characterEditorExecutionContextSchema>
 > {
-  public readonly defaultTemplateString = `Generate a list of comma-separated tags representing a character's typical clothing and accessories.
-
-Example output: blue jeans,red cardigan,white sneakers,canvas backpack
-
-The tags should describe what this character might typically wear on a regular day.
-
-Character description:
+  public readonly defaultTemplateString = `Here is the character description:
 <description>
 <%= it.focusedCharacter.internalDescription.replaceAll('{{user}}', 'the user').replaceAll('{{char}}', it.focusedCharacter.firstName) %>
+
 </description>
+
+<% if (it.focusedCharacter.wardrobes.length) { %>
+Here are the sets of tags we've already generated:
+<existing_tag_sets>
+<% for (const wardrobe of it.focusedCharacter.wardrobes) { %>
+<tag_set>
+<%= wardrobe.text %>
+
+</tag_set>
+<% } %>
+</existing_tag_sets>
+
+Generate a distinct list of comma-separated tags representing a set of clothing and accessories that the character might wear.
+<% } else { %>
+Generate a list of comma-separated tags representing a set of clothing and accessories that the character might wear.
+<% } %>
+
+Example output: blue jeans,red cardigan,white sneakers,canvas backpack
 
 Generate clothing/accessory tags for this character now. Output ONLY the comma-separated tags, nothing else.`;
 

--- a/client/src/engine/prompt_templates/chat/chat_system_prompt.ts
+++ b/client/src/engine/prompt_templates/chat/chat_system_prompt.ts
@@ -39,12 +39,12 @@ You are roleplaying as <%= it.focusedCharacter.firstName %> <%= it.focusedCharac
 <% for (const p of it.participants) { %>
 <% if (p.id !== it.focusedCharacter.id) { %>
 What <%= it.focusedCharacter.firstName %> knows about <%= p.firstName %> <%= p.lastName %>:
-<memories_of_<%= p.id %>>
+<memories_of_<%= p.xmlTagSafeName %>>
 <%= p.externalDescription %>
 
 <%= (await it.getRelationship(it.focusedCharacter.id, p.id))?.memory || it.focusedCharacter.firstName + ' has not met ' + p.firstName + ' yet. The previous information is surface level information that can be ascertained about ' + p.firstName + ' almost immediately when first meeting them.' %>
 
-</memories_of_<%= p.id %>>
+</memories_of_<%= p.xmlTagSafeName %>>
 <% } %>
 <% } %>
 
@@ -76,10 +76,10 @@ Location description: <%= it.currentLocation.description %>
 <% const shouldIncludeGossipMemory = !gossipTargetHasBeenRagged && it.gossipTargetCharacter && it.gossipTargetRelationship?.memory; %>
 <% if (shouldIncludeGossipMemory) { %>
 <%= it.focusedCharacter.firstName %> also knows another character named <%= it.gossipTargetCharacter.firstName %> <%= it.gossipTargetCharacter.lastName %>. <%= it.gossipTargetCharacter.firstName %> is not taking part in this conversation, but <%= it.focusedCharacter.firstName %> can mention <%= it.gossipTargetCharacter.firstName %> if it adds to the conversation. Here is <%= it.focusedCharacter.firstName %>'s relationship with <%= it.gossipTargetCharacter.firstName %>:
-<memories_of_<%= it.gossipTargetCharacter.id %>>
+<memories_of_<%= it.gossipTargetCharacter.xmlTagSafeName %>>
 <%= it.gossipTargetRelationship.memory %>
 
-</memories_of_<%= it.gossipTargetCharacter.id %>>
+</memories_of_<%= it.gossipTargetCharacter.xmlTagSafeName %>>
 <% } %>
 
 Your instructions:

--- a/client/src/engine/prompt_templates/chat/memory_rag_prompt.ts
+++ b/client/src/engine/prompt_templates/chat/memory_rag_prompt.ts
@@ -6,9 +6,9 @@ import { memoryRagExecutionContext } from '../prompt_template_context_fields';
 class MemoryRagPromptTemplate extends PromptTemplateBase<z.infer<typeof memoryRagExecutionContext>> {
   public readonly defaultTemplateString = `<% const mentioner = it.mentionedByCharacter.id === it.focusedCharacter.id ? 'You' : it.mentionedByCharacter.firstName; %>
 <%= mentioner %> may have just mentioned a character named <%= it.targetCharacter.firstName %> <%= it.targetCharacter.lastName %> who is not part of this chat. Here are your memories of <%= it.targetCharacter.firstName %> (if any):
-<memories_of_<%= it.targetCharacter.id %>>
+<memories_of_<%= it.targetCharacter.xmlTagSafeName %>>
 <%= it.targetCharacterRelationship.memory || 'You do not have any memories of ' + it.targetCharacter.firstName + ' yet' %>
-</memories_of_<%= it.targetCharacter.id %>>`;
+</memories_of_<%= it.targetCharacter.xmlTagSafeName %>>`;
   public readonly contextSchema = memoryRagExecutionContext;
 
   public readonly templateName = 'Memory RAG Prompt';

--- a/client/src/engine/prompt_templates/chat/moderation_next_speaker.ts
+++ b/client/src/engine/prompt_templates/chat/moderation_next_speaker.ts
@@ -69,14 +69,15 @@ const moderationNextSpeakerUserTemplate = new ModerationNextSpeakerUserTemplate(
 export const moderationNextSpeakerTemplatesGroup = new PromptTemplateChain({
   templateChainId: 'gen_intelligent_next_speaker_select',
   templateChainTitle: 'Next Speaker Selection',
-  templateChainDescription: 'Templates used for intelligent next speaker selection in group chat.',
+  templateChainDescription:
+    'Templates used for intelligent next speaker selection in group chat. Parser may return null to fall back to simple selection logic.',
   contextSchema: moderationNextSpeakerExecutionContextSchema,
   templates: [
     { template: moderationNextSpeakerSystemTemplate },
     { template: moderationNextSpeakerUserTemplate },
   ],
   parser: new PromptOutputParser<z.infer<typeof moderationNextSpeakerExecutionContextSchema>, string | null>(
-    `(response, it) => {
+    `async (response, it) => {
   const nextSpeakerName = response.split(/\\s/)[0]?.toLowerCase();
   return it.speakerCandidates.find(
     (candidate) => candidate.firstName.toLowerCase() === nextSpeakerName

--- a/client/src/engine/prompt_templates/memories/conversation_rolling_summary.ts
+++ b/client/src/engine/prompt_templates/memories/conversation_rolling_summary.ts
@@ -29,10 +29,10 @@ class ConversationRollingSummaryUserTemplate extends PromptTemplateBase<
   z.infer<typeof focusedConversationExecutionContextSchema>
 > {
   public readonly defaultTemplateString = `<%= it.focusedCharacter.firstName %>'s persona:
-<<%= it.focusedCharacter.firstName %>_persona>
+<persona>
 <%= it.focusedCharacter.internalDescription %>
 
-</<%= it.focusedCharacter.firstName %>_persona>
+</persona>
 
 Conversation participants: <%= it.participants.map((participant) => participant.firstName + ' ' + participant.lastName).join(', ') %>
 

--- a/client/src/engine/prompt_templates/memories/offscreen_memory_extraction.ts
+++ b/client/src/engine/prompt_templates/memories/offscreen_memory_extraction.ts
@@ -34,10 +34,10 @@ class OffscreenMemoryExtractionUserTemplate extends PromptTemplateBase<
   z.infer<typeof targetedConversationExecutionContextSchema>
 > {
   public readonly defaultTemplateString = `Here is <%= it.focusedCharacter.firstName %>'s persona:
-<<%= it.focusedCharacter.firstName %>_persona>
+<persona>
 <%= it.focusedCharacter.internalDescription %>
 
-</<%= it.focusedCharacter.firstName %>_persona>
+</persona>
 
 Here is the conversation transcript:
 <transcript>
@@ -71,7 +71,7 @@ export const offscreenMemoryExtractionChainGroup = new PromptTemplateChain({
   templateChainId: 'gen_offscreen_learned_information',
   templateChainTitle: 'Offscreen Memory Extraction',
   templateChainDescription:
-    'Prompts for extracting information learned about a character not participating in the conversation.',
+    'Prompts for extracting information learned about a character not participating in the conversation. The parser can return null if nothing new was learned.',
   contextSchema: targetedConversationExecutionContextSchema,
   templates: [
     { template: offscreenMemoryExtractionSystemTemplate },

--- a/client/src/engine/prompt_templates/memories/offscreen_memory_extraction.ts
+++ b/client/src/engine/prompt_templates/memories/offscreen_memory_extraction.ts
@@ -78,7 +78,7 @@ export const offscreenMemoryExtractionChainGroup = new PromptTemplateChain({
     { template: offscreenMemoryExtractionUserTemplate },
   ],
   parser: new PromptOutputParser<z.infer<typeof targetedConversationExecutionContextSchema>, string | null>(
-    `(response) => {
+    `async (response, it) => {
   if (response.includes('NONE')) {
     return null;
   }

--- a/client/src/engine/prompt_templates/memories/offscreen_memory_update_conversation_goal.ts
+++ b/client/src/engine/prompt_templates/memories/offscreen_memory_update_conversation_goal.ts
@@ -69,7 +69,7 @@ export const offscreenMemoryUpdateConversationGoalChainGroup = new PromptTemplat
   templateChainId: 'gen_offscreen_character_binary_update_next_convo_goal',
   templateChainTitle: 'Offscreen Conversation Goal Update',
   templateChainDescription:
-    'Two-message chain for deciding whether to keep the existing next-conversation goal or replace it with a new one.',
+    'Prompts for deciding whether to keep the existing next-conversation goal or replace it with a new one. Parser may return null to keep existing goal.',
   contextSchema: offscreenMemoryUpdateConversationGoalContextSchema,
   templates: [
     { template: offscreenMemoryUpdateConversationGoalSystemTemplate },
@@ -79,7 +79,7 @@ export const offscreenMemoryUpdateConversationGoalChainGroup = new PromptTemplat
     z.infer<typeof offscreenMemoryUpdateConversationGoalContextSchema>,
     string | null
   >(
-    `(response) => {
+    `async (response, it) => {
   if (response.includes('KEEP_OLD')) {
     return null;
   }

--- a/client/src/engine/prompt_templates/memories/offscreen_memory_update_conversation_goal.ts
+++ b/client/src/engine/prompt_templates/memories/offscreen_memory_update_conversation_goal.ts
@@ -80,7 +80,7 @@ export const offscreenMemoryUpdateConversationGoalChainGroup = new PromptTemplat
     string | null
   >(
     `(response) => {
-  if (response.includes('KEEP_OLD_GOAL')) {
+  if (response.includes('KEEP_OLD')) {
     return null;
   }
 

--- a/client/src/engine/prompt_templates/memories/rolling_global_memory_rewrite.ts
+++ b/client/src/engine/prompt_templates/memories/rolling_global_memory_rewrite.ts
@@ -30,10 +30,10 @@ class RollingGlobalMemoryRewriteUserTemplate extends PromptTemplateBase<
   z.infer<typeof focusedConversationExecutionContextSchema>
 > {
   public readonly defaultTemplateString = `<%= it.focusedCharacter.firstName %>'s persona:
-<<%= it.focusedCharacter.firstName %>_persona>
+<persona>
 <%= it.focusedCharacter.internalDescription %>
 
-</<%= it.focusedCharacter.firstName %>_persona>
+</persona>
 
 Current global memory:
 <old_global_memory>

--- a/client/src/engine/prompt_templates/prompt_context_builder.ts
+++ b/client/src/engine/prompt_templates/prompt_context_builder.ts
@@ -11,19 +11,28 @@ import {
 } from '../../state/active_chat_store.js';
 import { useScenarioStore } from '../../state/scenario_store.js';
 import type {
-  CharacterEditorContext,
+  CharacterEditorExecutionContext,
   ContextCharacter,
   ConversationExecutionContext,
   FocusedConversationExecutionContext,
   GlobalExecutionContext,
+  MemoryRagExectionContext,
+  ModerationNextSpeakerExecutionContext,
   ScenarioExecutionContext,
-  TargetedConversationContext,
+  TargetedConversationExecutionContext,
 } from './prompt_template_context_fields.js';
 import { useSettingsStore } from '../../state/settings_store.js';
 import { generatePersonalityTraits } from '../../util/personality.js';
 import _ from 'lodash';
 
 const globalWritableContext = {};
+
+function toContextCharacter(character: Character): ContextCharacter {
+  return {
+    ...character,
+    xmlTagSafeName: `${character.firstName}_${character.lastName}`.toLowerCase().replaceAll(/\s+/, '_'),
+  };
+}
 
 function formatPairwiseMemoriesForPrompt(
   relationship: CharacterRelationship,
@@ -111,8 +120,8 @@ function buildScenarioTemplateContext(): ScenarioExecutionContext {
 
   return {
     ...buildGlobalTemplateContext(),
-    allCharacters: Object.values(scenarioCharacterStore.scenarioCharactersById),
-    userCharacter,
+    allCharacters: Object.values(scenarioCharacterStore.scenarioCharactersById).map(toContextCharacter),
+    userCharacter: toContextCharacter(userCharacter),
     scenario: scenarioStore.activeScenario,
     worldMap: scenarioStore.activeScenarioMap,
     getRelationship: (characterAId: string, characterBId: string) =>
@@ -136,14 +145,19 @@ async function buildChatTemplateContext(focusedCharacter?: Character): Promise<C
     .map((id) => scenarioCharacterStore.scenarioCharactersById[id])
     .filter((char): char is Character => char !== undefined);
 
+  const { gossipTargetCharacter, gossipTargetRelationship } = await getActiveChatGossipCharacter(
+    focusedCharacter?.id
+  );
+
   return {
     ...(await buildScenarioTemplateContext()),
-    participants: getActiveChatParticipants(),
+    participants: getActiveChatParticipants().map(toContextCharacter),
     chatMedium: getActiveChatMedium(),
-    raggedCharacters,
+    raggedCharacters: raggedCharacters.map(toContextCharacter),
     transcript: activeChatStore.transcript.toTextTranscript(focusedCharacter?.id),
     conversationMessages: activeChatStore.transcript.getRawMessages(),
-    ...(await getActiveChatGossipCharacter(focusedCharacter?.id)),
+    gossipTargetCharacter: gossipTargetCharacter ? toContextCharacter(gossipTargetCharacter) : undefined,
+    gossipTargetRelationship,
   };
 }
 
@@ -161,10 +175,10 @@ export async function buildFocusedChatTemplateContext(
   return {
     ...chatTemplateContext,
     currentLocation,
-    focusedCharacter: focusedCharacter,
+    focusedCharacter: toContextCharacter(focusedCharacter),
     focusedCharacterAppearance: buildAppearanceTags(focusedCharacter),
     rollingConversationSummariesText: formatGlobalMemoriesForPrompt(
-      focusedCharacter,
+      toContextCharacter(focusedCharacter),
       chatTemplateContext.allCharacters
     ),
   };
@@ -173,7 +187,7 @@ export async function buildFocusedChatTemplateContext(
 export async function buildTargetedChatTemplateContext(
   focusedCharacterId: string,
   targetCharacterId: string
-): Promise<TargetedConversationContext> {
+): Promise<TargetedConversationExecutionContext> {
   const scenarioCharacterStore = useScenarioCharacterStore.getState();
   const focusedCharacter = scenarioCharacterStore.scenarioCharactersById[focusedCharacterId];
   const targetCharacter = scenarioCharacterStore.scenarioCharactersById[targetCharacterId];
@@ -185,7 +199,7 @@ export async function buildTargetedChatTemplateContext(
 
   return {
     ...focusedContext,
-    targetCharacter,
+    targetCharacter: toContextCharacter(targetCharacter),
     targetCharacterRelationship: await useScenarioCharacterRelationshipStore
       .getState()
       .getCharacterRelationship(focusedCharacter.id, targetCharacter.id),
@@ -193,25 +207,27 @@ export async function buildTargetedChatTemplateContext(
       await useScenarioCharacterRelationshipStore
         .getState()
         .getCharacterRelationship(focusedCharacter.id, targetCharacter.id),
-      focusedCharacter,
-      targetCharacter,
+      toContextCharacter(focusedCharacter),
+      toContextCharacter(targetCharacter),
       focusedContext.allCharacters
     ),
   };
 }
 
-export function buildCharacterEditorContext(focusedCharacter: Character): CharacterEditorContext {
+export function buildCharacterEditorContext(focusedCharacter: Character): CharacterEditorExecutionContext {
   return {
     ...buildGlobalTemplateContext(),
     randomPersonalityTraits: generatePersonalityTraits(),
-    focusedCharacter,
+    focusedCharacter: toContextCharacter(focusedCharacter),
   };
 }
 
-export async function buildChatModeratorContext(speakerCandidates: Character[]) {
+export async function buildChatModeratorContext(
+  speakerCandidates: Character[]
+): Promise<ModerationNextSpeakerExecutionContext> {
   return {
     ...(await buildChatTemplateContext()),
-    speakerCandidates,
+    speakerCandidates: speakerCandidates.map(toContextCharacter),
   };
 }
 
@@ -223,5 +239,16 @@ export async function buildOffscreenMemoryUpdateConversationGoalContext(
   return {
     ...(await buildTargetedChatTemplateContext(fromCharacterId, toCharacterId)),
     candidateInformation,
+  };
+}
+
+export async function buildMemoryRagTemplateContext(
+  focusedCharacter: Character,
+  mentionedCharacter: Character,
+  mentionedByCharacter: Character
+): Promise<MemoryRagExectionContext> {
+  return {
+    ...(await buildTargetedChatTemplateContext(focusedCharacter.id, mentionedCharacter.id)),
+    mentionedByCharacter: toContextCharacter(mentionedByCharacter),
   };
 }

--- a/client/src/engine/prompt_templates/prompt_context_builder.ts
+++ b/client/src/engine/prompt_templates/prompt_context_builder.ts
@@ -30,7 +30,7 @@ const globalWritableContext = {};
 function toContextCharacter(character: Character): ContextCharacter {
   return {
     ...character,
-    xmlTagSafeName: `${character.firstName}_${character.lastName}`.toLowerCase().replaceAll(/\s+/, '_'),
+    xmlTagSafeName: `${character.firstName}_${character.lastName}`.toLowerCase().replaceAll(/\s+/g, '_'),
   };
 }
 

--- a/client/src/engine/prompt_templates/prompt_template_context_fields.ts
+++ b/client/src/engine/prompt_templates/prompt_template_context_fields.ts
@@ -9,19 +9,27 @@ import {
   worldMapSchema,
 } from '../types';
 
-const characterSchema = internalCharacterSchema.pick({
-  id: true,
-  firstName: true,
-  lastName: true,
-  internalDescription: true,
-  externalDescription: true,
-  baseAppearanceTags: true,
-  wardrobes: true,
-  globalMemories: true,
-  locationId: true,
-  exampleDialogue: true,
-  rollingConversationSummaries: true,
-});
+const characterSchema = internalCharacterSchema
+  .pick({
+    id: true,
+    firstName: true,
+    lastName: true,
+    internalDescription: true,
+    externalDescription: true,
+    baseAppearanceTags: true,
+    wardrobes: true,
+    globalMemories: true,
+    locationId: true,
+    exampleDialogue: true,
+    rollingConversationSummaries: true,
+  })
+  .extend({
+    xmlTagSafeName: z.string().meta({
+      description:
+        'An encoding of the first and last name that is syntactically valid in the name of an XML tag',
+      examples: ['alice_smith'],
+    }),
+  });
 
 export type ContextCharacter = z.infer<typeof characterSchema>;
 
@@ -210,7 +218,7 @@ export const characterEditorExecutionContextSchema = globalExecutionContextSchem
   })
 );
 
-export type CharacterEditorContext = z.infer<typeof characterEditorExecutionContextSchema>;
+export type CharacterEditorExecutionContext = z.infer<typeof characterEditorExecutionContextSchema>;
 
 export const targetedConversationExecutionContextSchema = focusedConversationExecutionContextSchema.and(
   contextSchemaFields.pick({
@@ -219,13 +227,15 @@ export const targetedConversationExecutionContextSchema = focusedConversationExe
     targetCharacterFormattedRollingMemoriesText: true,
   })
 );
-export type TargetedConversationContext = z.infer<typeof targetedConversationExecutionContextSchema>;
+export type TargetedConversationExecutionContext = z.infer<typeof targetedConversationExecutionContextSchema>;
 
 export const memoryRagExecutionContext = targetedConversationExecutionContextSchema.and(
   contextSchemaFields.pick({
     mentionedByCharacter: true,
   })
 );
+
+export type MemoryRagExectionContext = z.infer<typeof memoryRagExecutionContext>;
 
 export const offscreenMemoryUpdateConversationGoalContextSchema =
   targetedConversationExecutionContextSchema.and(
@@ -239,7 +249,7 @@ export const offscreenMemoryUpdateConversationGoalContextSchema =
       })
   );
 
-type OffscreenMemoryUpdateConversationGoalContext = z.infer<
+type OffscreenMemoryUpdateConversationGoalExecutionContext = z.infer<
   typeof offscreenMemoryUpdateConversationGoalContextSchema
 >;
 
@@ -254,14 +264,17 @@ export const moderationNextSpeakerExecutionContextSchema = conversationExecution
     })
 );
 
-type ModerationNextSpeakerExecutionContext = z.infer<typeof moderationNextSpeakerExecutionContextSchema>;
+export type ModerationNextSpeakerExecutionContext = z.infer<
+  typeof moderationNextSpeakerExecutionContextSchema
+>;
 
 export type PromptExecutionContext =
   | GlobalExecutionContext
   | ScenarioExecutionContext
   | ConversationExecutionContext
   | FocusedConversationExecutionContext
-  | CharacterEditorContext
-  | TargetedConversationContext
-  | OffscreenMemoryUpdateConversationGoalContext
-  | ModerationNextSpeakerExecutionContext;
+  | CharacterEditorExecutionContext
+  | TargetedConversationExecutionContext
+  | OffscreenMemoryUpdateConversationGoalExecutionContext
+  | ModerationNextSpeakerExecutionContext
+  | MemoryRagExectionContext;

--- a/client/src/engine/scenario_loop/flow_control.ts
+++ b/client/src/engine/scenario_loop/flow_control.ts
@@ -1,5 +1,12 @@
 import type { ChatUserInputAction, UserTurnAction } from './types';
 
+export class UserAbortSignalException extends Error {
+  public constructor(message = 'User aborted the current NPC turn') {
+    super(message);
+    this.name = 'UserAbortSignalException';
+  }
+}
+
 export class ScenarioLoopAbortSignalException extends Error {}
 
 class ScenarioLoopPromise<TReturnType> {

--- a/client/src/engine/scenario_loop/scenario_loop.ts
+++ b/client/src/engine/scenario_loop/scenario_loop.ts
@@ -82,51 +82,56 @@ async function runChatLoop(
     await doScenarioLoopAsyncAction(() => ChatCoordinator.activate(participantIds));
   }
 
-  let nextSpeaker = await doScenarioLoopAsyncAction(() => ChatCoordinator.selectNextSpeaker());
+  try {
+    let nextSpeaker = await doScenarioLoopAsyncAction(() => ChatCoordinator.selectNextSpeaker());
 
-  while (true) {
-    const numMessagesSent = ChatCoordinator.countChatMessages();
-    if (numMessagesSent >= getChatMessageLimit()) {
-      return closeChatSession();
-    }
-
-    const userCharacter = useScenarioCharacterStore.getState().getUserCharacter();
-
-    if (userCharacter && nextSpeaker.id === userCharacter.id) {
-      ChatCoordinator.setStateAwaitingUserInput();
-      const userChatAction = await doWithScenarioLoopPromise<ChatUserInputAction>(
-        async (userChatActionPromise) => {
-          scenarioLoopPromiseCallbacks.userChatAction = userChatActionPromise;
-          return userChatActionPromise.promise;
-        }
-      );
-
-      if (userChatAction.actionType === 'skip_turn') {
-        nextSpeaker = await doScenarioLoopAsyncAction(() =>
-          ChatCoordinator.selectNextSpeaker({ notSpeakerId: nextSpeaker.id })
-        );
-      } else if (userChatAction.actionType === 'speak_as') {
-        nextSpeaker = await doScenarioLoopAsyncAction(() =>
-          ChatCoordinator.selectNextSpeaker({ forcedSpeakerId: userChatAction.characterId })
-        );
-      } else if (userChatAction.actionType === 'request_end_chat') {
-        const transcript = useActiveChatStore.getState().transcript;
-        assertNonNullish(transcript, 'No chat transcript');
-        return closeChatSession(userChatAction.forceNoEffect);
-      } else if (userChatAction.actionType === 'send_message') {
-        await doScenarioLoopAsyncAction(() =>
-          ChatCoordinator.addCharacterMessage(userCharacter.id, userChatAction.message)
-        );
-
-        nextSpeaker = await doScenarioLoopAsyncAction(() => ChatCoordinator.selectNextSpeaker());
-      } else {
-        assert(false, 'Unexpected user chat action');
+    while (true) {
+      const numMessagesSent = ChatCoordinator.countChatMessages();
+      if (numMessagesSent >= getChatMessageLimit()) {
+        return closeChatSession();
       }
-    } else {
-      ChatCoordinator.setStateNpcSpeaking();
-      await doScenarioLoopAsyncAction(() => ChatCoordinator.speakAsNpc(nextSpeaker.id));
-      nextSpeaker = await doScenarioLoopAsyncAction(() => ChatCoordinator.selectNextSpeaker());
+
+      const userCharacter = useScenarioCharacterStore.getState().getUserCharacter();
+
+      if (userCharacter && nextSpeaker.id === userCharacter.id) {
+        ChatCoordinator.setStateAwaitingUserInput();
+        const userChatAction = await doWithScenarioLoopPromise<ChatUserInputAction>(
+          async (userChatActionPromise) => {
+            scenarioLoopPromiseCallbacks.userChatAction = userChatActionPromise;
+            return userChatActionPromise.promise;
+          }
+        );
+
+        if (userChatAction.actionType === 'skip_turn') {
+          nextSpeaker = await doScenarioLoopAsyncAction(() =>
+            ChatCoordinator.selectNextSpeaker({ notSpeakerId: nextSpeaker.id })
+          );
+        } else if (userChatAction.actionType === 'speak_as') {
+          nextSpeaker = await doScenarioLoopAsyncAction(() =>
+            ChatCoordinator.selectNextSpeaker({ forcedSpeakerId: userChatAction.characterId })
+          );
+        } else if (userChatAction.actionType === 'request_end_chat') {
+          const transcript = useActiveChatStore.getState().transcript;
+          assertNonNullish(transcript, 'No chat transcript');
+          return closeChatSession(userChatAction.forceNoEffect);
+        } else if (userChatAction.actionType === 'send_message') {
+          await doScenarioLoopAsyncAction(() =>
+            ChatCoordinator.addCharacterMessage(userCharacter.id, userChatAction.message)
+          );
+
+          nextSpeaker = await doScenarioLoopAsyncAction(() => ChatCoordinator.selectNextSpeaker());
+        } else {
+          assert(false, 'Unexpected user chat action');
+        }
+      } else {
+        ChatCoordinator.setStateNpcSpeaking();
+        await doScenarioLoopAsyncAction(() => ChatCoordinator.speakAsNpc(nextSpeaker.id));
+        nextSpeaker = await doScenarioLoopAsyncAction(() => ChatCoordinator.selectNextSpeaker());
+      }
     }
+  } catch (err) {
+    await closeChatSession(true);
+    throw err;
   }
 }
 
@@ -236,10 +241,20 @@ async function runScenarioLoop(opts: { resumeRestoredChat: boolean }) {
   let resumeRestoredChat = opts.resumeRestoredChat;
 
   while (true) {
-    runWardrobeAutoselect();
-    await runUserPhase({ resumeRestoredChat });
-    resumeRestoredChat = false;
-    await runNpcPhase();
+    try {
+      runWardrobeAutoselect();
+      await runUserPhase({ resumeRestoredChat });
+      resumeRestoredChat = false;
+      await runNpcPhase();
+    } catch (err) {
+      await showNonRetriableErrorCardIfNeeded({
+        operationType: 'chat_loop_top_level',
+        error: err as Error,
+      });
+
+      // If error is instance of the new UserAbortSignalException error, continue the loop. Otherwise, re-throw.
+      throw err;
+    }
   }
 }
 
@@ -283,7 +298,7 @@ export async function startScenarioLoop() {
       operationType: 'scenario_loop.run_loop',
       error: err,
       messagePrefix: 'Scenario loop fatal error',
-      hint: 'The scenario loop is no longer running. Try refreshing the page.',
+      hint: 'The scenario loop is no longer running. Try restarting the application.',
     });
 
     throw err;

--- a/client/src/engine/scenario_loop/scenario_loop.ts
+++ b/client/src/engine/scenario_loop/scenario_loop.ts
@@ -18,6 +18,7 @@ import {
   doWithScenarioLoopPromise,
   ScenarioLoopAbortSignalException,
   scenarioLoopPromiseCallbacks,
+  UserAbortSignalException,
 } from './flow_control';
 import type { ChatUserInputAction, UserTurnAction } from './types';
 
@@ -247,12 +248,21 @@ async function runScenarioLoop(opts: { resumeRestoredChat: boolean }) {
       resumeRestoredChat = false;
       await runNpcPhase();
     } catch (err) {
+      // The user paused/stopped the NPC turn: hand control back to the user character by
+      // looping back to the user phase, disable auto mode, and clear the request. No error
+      // card is shown since this is a deliberate user action, not a failure.
+      if (err instanceof UserAbortSignalException) {
+        const loopState = useScenarioLoopStateStore.getState();
+        loopState.setAutoMode(false);
+        loopState.setUserRequestedPhaseTransition('none');
+        continue;
+      }
+
       await showNonRetriableErrorCardIfNeeded({
         operationType: 'chat_loop_top_level',
         error: err as Error,
       });
 
-      // If error is instance of the new UserAbortSignalException error, continue the loop. Otherwise, re-throw.
       throw err;
     }
   }

--- a/client/src/pages/ScenarioView.tsx
+++ b/client/src/pages/ScenarioView.tsx
@@ -41,6 +41,12 @@ export default function ScenarioView() {
   const submitUserChatAction = useScenarioLoopStateStore((state) => state.submitUserChatAction);
   const autoModeEnabled = useScenarioLoopStateStore((state) => state.autoMode);
   const setAutoModeEnabled = useScenarioLoopStateStore((state) => state.setAutoMode);
+  const userRequestedPhaseTransition = useScenarioLoopStateStore(
+    (state) => state.userRequestedPhaseTransition
+  );
+  const setUserRequestedPhaseTransition = useScenarioLoopStateStore(
+    (state) => state.setUserRequestedPhaseTransition
+  );
   const npcPhaseBusy = currentPhase === 'npc';
   const canSubmitUserTurn = currentPhase === 'user' && !hasActiveChatSession;
   const previousUserIdRef = useRef<string | null>(null);
@@ -218,6 +224,9 @@ export default function ScenarioView() {
   const resolvedLocation = location || activeMap.locations[0];
   assertNonNullish(resolvedLocation, 'No valid current location available for user location.');
 
+  const showNpcPhaseControls = npcPhaseBusy && !activeChatIncludesUser;
+  const npcTurnPaused = userRequestedPhaseTransition === 'paused';
+
   const renderSessionHeader = ({ includeMenu = false }: { includeMenu?: boolean } = {}) => (
     <div className="flex justify-between items-center">
       <div className="font-semibold">
@@ -260,7 +269,30 @@ export default function ScenarioView() {
               submitUserWait();
             }}
             disabled={!canSubmitUserTurn}
+            canMove={!showNpcPhaseControls}
           />
+
+          {showNpcPhaseControls && (
+            <div>
+              <div className="font-semibold mb-1">NPC turn</div>
+              <div className="flex gap-2 flex-wrap">
+                <button
+                  type="button"
+                  className="border-warning-border bg-warning-bg text-warning-text-strong hover:bg-warning-border-soft"
+                  onClick={() => setUserRequestedPhaseTransition(npcTurnPaused ? 'none' : 'paused')}
+                >
+                  {npcTurnPaused ? '▶ Resume' : '⏸ Pause'}
+                </button>
+                <button
+                  type="button"
+                  className="border-danger-border-accent bg-danger-solid text-on-accent hover:bg-danger-solid-hover"
+                  onClick={() => setUserRequestedPhaseTransition('stopped')}
+                >
+                  ■ Stop
+                </button>
+              </div>
+            </div>
+          )}
 
           {hasActiveChatSession && (
             <div className="mx-auto py-6 space-y-3">

--- a/client/src/state/scenario_loop_state_store.ts
+++ b/client/src/state/scenario_loop_state_store.ts
@@ -10,16 +10,20 @@ import { useActiveChatStore } from './active_chat_store';
 
 type ScenarioLoopPhase = 'user' | 'npc';
 
+export type UserRequestedPhaseTransition = 'none' | 'paused' | 'stopped';
+
 type ScenarioLoopStateStoreState = {
   currentPhase: ScenarioLoopPhase;
   autoMode: boolean;
   runState: ScenarioLoopRunState;
   runningForScenario: string | undefined;
+  userRequestedPhaseTransition: UserRequestedPhaseTransition;
 
   setScenario: (scenarioId: string | undefined) => void;
   setPhase: (phase: ScenarioLoopPhase) => void;
   setAutoMode: (enabled: boolean) => void;
   setRunState: (runState: ScenarioLoopRunState) => void;
+  setUserRequestedPhaseTransition: (value: UserRequestedPhaseTransition) => void;
   resetLoopState: () => void;
   submitChatMessage: (message: string) => boolean;
   submitChatSkipTurn: () => boolean;
@@ -61,6 +65,7 @@ export const useScenarioLoopStateStore = create<ScenarioLoopStateStoreState>((se
   autoMode: false,
   runState: 'idle',
   runningForScenario: undefined,
+  userRequestedPhaseTransition: 'none',
 
   setPhase(phase: ScenarioLoopPhase) {
     set({
@@ -78,10 +83,15 @@ export const useScenarioLoopStateStore = create<ScenarioLoopStateStoreState>((se
     set({ runState });
   },
 
+  setUserRequestedPhaseTransition(value: UserRequestedPhaseTransition) {
+    set({ userRequestedPhaseTransition: value });
+  },
+
   resetLoopState() {
     set({
       currentPhase: 'user',
       runState: 'idle',
+      userRequestedPhaseTransition: 'none',
     });
   },
 

--- a/client/src/util/phase_transition_gate.ts
+++ b/client/src/util/phase_transition_gate.ts
@@ -1,0 +1,41 @@
+import { UserAbortSignalException } from '../engine/scenario_loop/flow_control.js';
+import { useScenarioLoopStateStore } from '../state/scenario_loop_state_store.js';
+
+export async function withPhaseTransitionGate<T>(fn: (signal: AbortSignal) => Promise<T>): Promise<T> {
+  let { userRequestedPhaseTransition } = useScenarioLoopStateStore.getState();
+
+  if (userRequestedPhaseTransition === 'paused') {
+    await new Promise((resolve) => {
+      const unsubscribe = useScenarioLoopStateStore.subscribe((state) => {
+        userRequestedPhaseTransition = state.userRequestedPhaseTransition;
+        if (userRequestedPhaseTransition !== 'paused') {
+          unsubscribe();
+          resolve(undefined);
+        }
+      });
+    });
+  }
+
+  if (userRequestedPhaseTransition === 'stopped') {
+    throw new UserAbortSignalException();
+  }
+
+  const abortController = new AbortController();
+
+  const unsubscribe = useScenarioLoopStateStore.subscribe((state) => {
+    if (state.userRequestedPhaseTransition === 'stopped') {
+      abortController.abort();
+    }
+  });
+
+  try {
+    return await fn(abortController.signal);
+  } catch (error) {
+    if (abortController.signal.aborted) {
+      throw new UserAbortSignalException();
+    }
+    throw error;
+  } finally {
+    unsubscribe();
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  yozakura:
+    # For now, the public image only supports Intel/AMD CPUs. If you are
+	  # on ARM, comment out the 'image' line and uncomment the 'build' line
+    image: ghcr.io/mistval/yozakura:latest
+    # build: .
+    container_name: yozakura
+    init: true
+    network_mode: host
+    volumes:
+      - ./yozakura_data:/app/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   yozakura:
     # For now, the public image only supports Intel/AMD CPUs. If you are
-	  # on ARM, comment out the 'image' line and uncomment the 'build' line
+    # on ARM, comment out the 'image' line and uncomment the 'build' line
     image: ghcr.io/mistval/yozakura:latest
     # build: .
     container_name: yozakura

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -28,18 +28,20 @@ Installation:
 
 ## Docker
 
-Prerequisites:
+### Prerequisites:
 
 1. You need access to an LLM via a completions API.
 2. You need to have [Docker](https://docs.docker.com/desktop/) installed
 
-Installation:
+### Installation:
 
-1. Run `docker run -p 4396:4396 -d ghcr.io/mistval/yozakura:latest`
+**Using Docker compose**: Save this [docker-compose.yml](https://github.com/mistval/yozakura/blob/main/docker-compose.yml) file somewhere and run `docker compose up -d` in that directory.
 
-If you want to use local models, you generally need to add `--network=host` to your Docker command, which **might not work at all on Windows**. As a workaround, you could create a Docker network, run your models inside Docker containers too, and network them together, but that's beyond the scope of this article.
+**Or without compose**: Run `docker run --network host -v ./yozakura_data:/app/data -d ghcr.io/mistval/yozakura:latest`.
 
-If you want to put your yozakura_data directory somewhere easily accessible, add a volume option to the command like: `docker run -p 4396:4396 -d -v /d/yozakura_data:/app/data ghcr.io/mistval/yozakura:latest`. If you don't do this, yozakura will create an anonymous volume, but you'll have to deal with re-attaching it to the new container if you ever pull a new image.
+In both cases, your data will be saved to a `yozakura_data` folder in the current working directory.
+
+Both methods use host network mode in order to have access to APIs you're running on your local machine. If you are not running text completions or image generation APIs on your local machine, you can remove the host network mode option. Note that host network mode **might not work at all on Windows**.
 
 Give it just a few moments to start, then visit `http://localhost:4396` in your web browser.
 

--- a/scripts/export-prompt-template-context-schemas.ts
+++ b/scripts/export-prompt-template-context-schemas.ts
@@ -245,6 +245,8 @@ async function main(): Promise<void> {
   for (const chain of chains) {
     console.log(`- ${chain.templateChainId} -> ${chain.schemaFileName}`);
   }
+
+  process.exit(0);
 }
 
 void main();

--- a/server/app.ts
+++ b/server/app.ts
@@ -2,6 +2,8 @@ import express, { type Express, type Request, type Response, type NextFunction }
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { openDatabase } from './database.js';
+import { runMigrations } from './migrator.js';
 import dbRouter from './routes/db.js';
 import filesRouter from './routes/files.js';
 import imageRouter from './routes/image.js';
@@ -31,11 +33,14 @@ export function createApp(options: CreateAppOptions = {}): Express {
 
   fs.mkdirSync(staticDir, { recursive: true });
 
+  const db = openDatabase(dataDir);
+  runMigrations(db);
+
   const app = express();
   app.use(express.json({ limit: '10mb' }));
 
   app.use('/api', filesRouter(dataDir));
-  app.use('/api', dbRouter(dataDir));
+  app.use('/api', dbRouter(db));
   app.use('/api', llmRouter());
   app.use('/api', imageRouter(dataDir));
 

--- a/server/database.ts
+++ b/server/database.ts
@@ -1,0 +1,20 @@
+import fs from 'fs';
+import path from 'path';
+import Database from 'better-sqlite3';
+
+/**
+ * Opens (creating the file and parent directory if needed) the application
+ * SQLite database and applies the connection-level pragmas that every part of
+ * the server relies on.
+ */
+export function openDatabase(dataDir: string): Database.Database {
+  fs.mkdirSync(dataDir, { recursive: true });
+  const dbPath = path.join(dataDir, 'app.sqlite');
+  const db = new Database(dbPath);
+
+  db.pragma('foreign_keys = ON');
+  db.pragma('journal_mode = WAL');
+  db.pragma('synchronous = NORMAL');
+
+  return db;
+}

--- a/server/migrations/0000_initial_schema.ts
+++ b/server/migrations/0000_initial_schema.ts
@@ -1,0 +1,95 @@
+import type { Migration } from '../types.js';
+
+const CREATE_INITIAL_SCHEMA_SQL = `
+  CREATE TABLE IF NOT EXISTS character (
+    id TEXT PRIMARY KEY,
+    data TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (CONCAT(datetime('now'), 'Z')),
+    updated_at TEXT NOT NULL DEFAULT (CONCAT(datetime('now'), 'Z'))
+  );
+
+  CREATE TABLE IF NOT EXISTS scenario_character (
+    id TEXT PRIMARY KEY,
+    scenario_id TEXT NOT NULL,
+    data TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (CONCAT(datetime('now'), 'Z')),
+    updated_at TEXT NOT NULL DEFAULT (CONCAT(datetime('now'), 'Z')),
+    FOREIGN KEY (scenario_id) REFERENCES scenario(id) ON DELETE CASCADE
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_scenario_character_scenario_character
+    ON scenario_character(scenario_id);
+
+  CREATE TABLE IF NOT EXISTS scenario (
+    id TEXT PRIMARY KEY,
+    data TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (CONCAT(datetime('now'), 'Z')),
+    updated_at TEXT NOT NULL DEFAULT (CONCAT(datetime('now'), 'Z'))
+  );
+
+  CREATE TABLE IF NOT EXISTS character_relationship (
+    id TEXT PRIMARY KEY,
+    from_id TEXT NOT NULL,
+    to_id TEXT NOT NULL,
+    data TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (CONCAT(datetime('now'), 'Z')),
+    updated_at TEXT NOT NULL DEFAULT (CONCAT(datetime('now'), 'Z')),
+    UNIQUE(from_id, to_id),
+    FOREIGN KEY (from_id) REFERENCES scenario_character(id) ON DELETE CASCADE,
+    FOREIGN KEY (to_id) REFERENCES scenario_character(id) ON DELETE CASCADE
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_character_relationship_from_to
+    ON character_relationship(from_id, to_id);
+
+  CREATE INDEX IF NOT EXISTS idx_character_relationship_to_from
+    ON character_relationship(to_id, from_id);
+
+  CREATE TABLE IF NOT EXISTS conversation (
+    id TEXT PRIMARY KEY,
+    scenario_id TEXT NOT NULL,
+    data TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (CONCAT(datetime('now'), 'Z')),
+    updated_at TEXT NOT NULL DEFAULT (CONCAT(datetime('now'), 'Z')),
+    FOREIGN KEY (scenario_id) REFERENCES scenario(id) ON DELETE CASCADE
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_conversation_scenario_updated_at_desc
+    ON conversation(scenario_id, updated_at DESC);
+
+  CREATE TABLE IF NOT EXISTS conversation_participant (
+    id TEXT PRIMARY KEY,
+    character_id TEXT NOT NULL,
+    conversation_id TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (CONCAT(datetime('now'), 'Z')),
+    updated_at TEXT NOT NULL DEFAULT (CONCAT(datetime('now'), 'Z')),
+    UNIQUE(character_id, conversation_id),
+    FOREIGN KEY (conversation_id) REFERENCES conversation(id) ON DELETE CASCADE
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_conversation_participant_character_updated_at_desc
+    ON conversation_participant(character_id, updated_at DESC);
+
+  CREATE INDEX IF NOT EXISTS idx_conversation_participant_conversation_character
+    ON conversation_participant(conversation_id, character_id);
+
+  CREATE TABLE IF NOT EXISTS map (
+    id TEXT PRIMARY KEY,
+    data TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (CONCAT(datetime('now'), 'Z')),
+    updated_at TEXT NOT NULL DEFAULT (CONCAT(datetime('now'), 'Z'))
+  );
+
+  CREATE TABLE IF NOT EXISTS key_value (
+    key TEXT PRIMARY KEY,
+    data TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (CONCAT(datetime('now'), 'Z')),
+    updated_at TEXT NOT NULL DEFAULT (CONCAT(datetime('now'), 'Z'))
+  );
+`;
+
+export const migration: Migration = {
+  doMigration(db) {
+    db.exec(CREATE_INITIAL_SCHEMA_SQL);
+  },
+};

--- a/server/migrator.ts
+++ b/server/migrator.ts
@@ -1,0 +1,45 @@
+import type Database from 'better-sqlite3';
+import { migration as migration0000InitialSchema } from './migrations/0000_initial_schema.js';
+import type { Migration } from './types.js';
+
+/**
+ * The ordered, append-only list of migrations. The array index of a migration
+ * is its version: a database at `PRAGMA user_version = N` still needs the
+ * migration at index `N` applied, after which `user_version` becomes `N + 1`.
+ *
+ * Never reorder or remove entries; only append new migrations to the end.
+ */
+const migrations: Migration[] = [migration0000InitialSchema];
+
+function getUserVersion(db: Database.Database): number {
+  return Number(db.pragma('user_version', { simple: true }));
+}
+
+export function runMigrations(db: Database.Database): void {
+  while (true) {
+    const version = getUserVersion(db);
+    const migration = migrations[version];
+
+    if (!migration) {
+      return;
+    }
+
+    const applyMigration = db.transaction(() => {
+      const versionInTransaction = getUserVersion(db);
+      if (versionInTransaction !== version) {
+        throw new Error(
+          `user_version changed from ${version} to ${versionInTransaction} before the migration could run`
+        );
+      }
+
+      migration.doMigration(db);
+      db.pragma(`user_version = ${version + 1}`);
+    });
+
+    try {
+      applyMigration.immediate();
+    } catch (error) {
+      throw new Error(`Migration ${version} failed: ${(error as Error).message}`, { cause: error });
+    }
+  }
+}

--- a/server/routes/db.ts
+++ b/server/routes/db.ts
@@ -1,7 +1,5 @@
 import express from 'express';
-import fs from 'fs';
-import path from 'path';
-import Database from 'better-sqlite3';
+import type Database from 'better-sqlite3';
 import { LRUCache } from 'lru-cache';
 import type { Router } from 'express';
 import z from 'zod';
@@ -9,18 +7,6 @@ import assert from 'assert';
 
 function toErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
-}
-
-function ensureDatabase(dataDir: string): Database.Database {
-  fs.mkdirSync(dataDir, { recursive: true });
-  const dbPath = path.join(dataDir, 'app.sqlite');
-  const db = new Database(dbPath);
-
-  db.pragma('foreign_keys = ON');
-  db.pragma('journal_mode = WAL');
-  db.pragma('synchronous = NORMAL');
-
-  return db;
 }
 
 const execSchema = z.object({
@@ -32,10 +18,8 @@ const allSchema = z.object({
   parameterGroups: z.array(z.array(z.unknown())),
 });
 
-export default function dbRouter(dataDir: string): Router {
+export default function dbRouter(db: Database.Database): Router {
   const router = express.Router();
-
-  const db = ensureDatabase(dataDir);
 
   const preparedStatementCache = new LRUCache<string, Database.Statement>({
     max: 1000,

--- a/server/routes/image.ts
+++ b/server/routes/image.ts
@@ -27,6 +27,13 @@ export default function imageRouter(dataDir: string): Router {
   const router = express.Router();
 
   router.post('/image/generate', async (req, res, next) => {
+    const upstreamAbortController = new AbortController();
+    res.on('close', () => {
+      if (!res.writableEnded) {
+        upstreamAbortController.abort();
+      }
+    });
+
     try {
       const parsed = bodySchema.parse(req.body);
       const { saveTo, imageApiUrl, imageApiShape, authToken, ...payload } = parsed;
@@ -43,6 +50,7 @@ export default function imageRouter(dataDir: string): Router {
           method: 'POST',
           headers: requestHeaders,
           body: JSON.stringify(payload),
+          signal: upstreamAbortController.signal,
         });
 
         if (!response.ok) {

--- a/server/routes/llm.ts
+++ b/server/routes/llm.ts
@@ -54,6 +54,13 @@ export default function llmRouter() {
   const router = express.Router();
 
   router.post('/llm/chat', async (req, res) => {
+    const upstreamAbortController = new AbortController();
+    res.on('close', () => {
+      if (!res.writableEnded) {
+        upstreamAbortController.abort();
+      }
+    });
+
     try {
       const parsed = completionsRequestSchema.parse(req.body);
       const { targetUrl, authToken, ...llmPayload } = parsed;
@@ -68,6 +75,7 @@ export default function llmRouter() {
         method: 'POST',
         headers,
         body: JSON.stringify(llmPayload),
+        signal: upstreamAbortController.signal,
       });
 
       res.status(response.status);

--- a/server/types.ts
+++ b/server/types.ts
@@ -1,0 +1,12 @@
+import type Database from 'better-sqlite3';
+
+export type Migration = {
+  /**
+   * Applies a single forward migration. Runs inside a transaction that also
+   * bumps `PRAGMA user_version`, so an implementation should only perform the
+   * schema/data changes and let the migrator handle versioning and commits.
+   *
+   * Must be synchronous: better-sqlite3 transactions cannot span awaits.
+   */
+  doMigration: (db: Database.Database) => void;
+};


### PR DESCRIPTION
* Pause and stop buttons so you can pause during the NPC phase, or cancel it entirely and advanced to user phase.
* Make the default wardrobe prompt better at producing distinct wardrobes and not repeating the same one over and over.
* Fix mousedown inside of modal and mouseup outside of it would cause the modal to close
* Make default parser for gen_offscreen_character_binary_update_next_convo_goal a little more forgiving
* Misc documentation improvements
* Add CONTRIBUTORS.md
* Fix that app version was not showing on the about page
* Ability to delete conversation summaries and offscreen learned info
* Establish process for database migration
* Standardize on using an XML-safe version of character names when character-related XML tags require disambiguation
* Make cancelled errors kill the NPC turn instead of putting you into a terminal error loop